### PR TITLE
Fix rain rate timestamp to use window midpoint

### DIFF
--- a/rain_agg.go
+++ b/rain_agg.go
@@ -175,7 +175,9 @@ func RainAgg(args RainAggArgs) ([]*influxdb.Point, error) {
 		retv = append(retv, p)
 	}
 
-	// rain rate (rain over past 10 minutes, extrapolated to per-hour):
+	// rain rate (rain over past 10 minutes, extrapolated to per-hour).
+	// timestamp at the midpoint of the 10-minute window (T-5min) rather than the
+	// trailing edge, since the rate is an aggregate over that window.
 	var rateData []rainDataPoint
 	for _, dp := range allData {
 		if latestTime.Sub(dp.t) <= 10*time.Minute {
@@ -189,7 +191,7 @@ func RainAgg(args RainAggArgs) ([]*influxdb.Point, error) {
 			map[string]any{
 				args.RainField + "_rate": accumRain(rateData) * 6,
 			},
-			latestTime,
+			latestTime.Add(-5*time.Minute),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create InfluxDB point: %w", err)


### PR DESCRIPTION
## Summary

- The rain rate metric is computed over a trailing 10-minute window, but was being written at timestamp T (the trailing edge), introducing a 5-minute time bias
- Write it at T-5min (the window midpoint) instead, which better represents when the measured rainfall actually occurred

## Test plan

- [ ] Verify the program builds successfully (`go build ./...`)
- [ ] Confirm rain rate data points in InfluxDB are now timestamped 5 minutes before the latest raw data point

https://claude.ai/code/session_0176X5xYuGbMnuGXgRVDwFgQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the timestamp assignment for rain rate data points to reflect the midpoint of the aggregation window rather than the end, improving temporal accuracy of recorded measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->